### PR TITLE
Changed Connection to MongoClient due to deprection

### DIFF
--- a/nozama-cloudsearch-data/nozama/cloudsearch/data/db.py
+++ b/nozama-cloudsearch-data/nozama/cloudsearch/data/db.py
@@ -3,7 +3,7 @@
 """
 import logging
 
-from pymongo import Connection
+from pymongo import MongoClient
 
 
 class DB(object):


### PR DESCRIPTION
Hi,
I installed the the service today with python 2.7 and after running it I got exception for the Connection class (pymongo version 3.0.3).

After changing deperecated Connection class to MongoClient everything worked fine.

Thanks,
Viktor