### PR TITLE
Fix #4: lock PyMongo at the required API version

### DIFF
--- a/nozama-cloudsearch-data/setup.py
+++ b/nozama-cloudsearch-data/setup.py
@@ -44,7 +44,7 @@ needed = [
     'requests==1.2.3',
     'cmdln',
     'formencode',
-    'pymongo',
+    'pymongo==2.8.1',
     'pyelasticsearch',
     "evasion-common==1.0.3",
 ]


### PR DESCRIPTION
This was the latest 2.x release, and fixes the `ImportError` on startup.