### PR TITLE
'add' in cloudsearch equals to 'upsert' in mongo

### DIFF
--- a/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
+++ b/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
@@ -218,8 +218,8 @@ def load(docs_to_load):
 
     if to_load:
         log.debug("bulk loading: '{0}' document(s)".format(len(to_load)))
-        conn.documents.insert(to_load)
         for doc in to_load:
+            conn.documents.update({'_id': doc['id']}, doc, True)
             add_to_elasticsearch(doc)
 
     if to_remove:


### PR DESCRIPTION
`add` operation in cloudsearch is `upsert` operation, that means always overwriting a document.
`update` with upsert option is more suitable than `insert`.

See:
https://docs.mongodb.com/manual/reference/method/db.collection.update/