### PR TITLE
version is not required attribute

### DIFF
--- a/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
+++ b/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
@@ -61,8 +61,6 @@ class DocSchema(formencode.Schema):
 
     #fields = FieldsSchema(not_empty=True)
 
-    version = validators.String(not_empty=True, strip=True)
-
     type = validators.OneOf(
         ["add", "delete"], not_empty=True, strip=True,
     )

--- a/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
+++ b/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
@@ -49,6 +49,7 @@ class FieldsSchema(formencode.Schema):
     allow_extra_fields = True
 
 
+from datetime import datetime
 class DocSchema(formencode.Schema):
     """Validate the document and the add/remove operation.
 
@@ -60,6 +61,8 @@ class DocSchema(formencode.Schema):
     lang = validators.String(not_empty=True, strip=True, if_missing='en')
 
     #fields = FieldsSchema(not_empty=True)
+
+    version = validators.String(strip=True, if_missing=datetime.now().strftime('%s'))
 
     type = validators.OneOf(
         ["add", "delete"], not_empty=True, strip=True,


### PR DESCRIPTION
I can't find any documentation saying that `version` is required.
There is no `version` attribute in examples here.
https://docs.aws.amazon.com/cloudsearch/latest/developerguide/preparing-data.html
It should be optional like 'lang' attribute.
