### PR TITLE
Return field values in sdk format

### DIFF
--- a/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
+++ b/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
@@ -125,6 +125,7 @@ def search(query={}):
 
     qstring = query.get('q', '')
     log.debug("searching query '{0}'".format(query))
+    formatType = query.get('format', '')
 
     try:
         if qstring:
@@ -149,13 +150,20 @@ def search(query={}):
             took=0,
         )
 
+    hit = []
+    conn = db().conn()
+    for i in results['hits']['hits']:
+        query = dict(_id=i['_id'])
+        fields = conn.documents.find_one(query)['fields']
+        hit.append({'id': i['_id'], 'fields': fields})
+
     rc = {
         "rank": "-text_relevance",
         "match-expr": "(label '{0}')".format(qstring),
         "hits": {
             "found": results['hits']['total'],
             "start": 0,
-            "hit": [{"id": i['_id']} for i in results['hits']['hits']]
+            "hit": hit
         },
         "info": {
             "rid": os.urandom(40).encode('hex'),

--- a/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
+++ b/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
@@ -155,6 +155,10 @@ def search(query={}):
     for i in results['hits']['hits']:
         query = dict(_id=i['_id'])
         fields = conn.documents.find_one(query)['fields']
+        if formatType == u'sdk':
+            for key, value in fields.items():
+                if not isinstance(value, list):
+                    fields[key] = [value]
         hit.append({'id': i['_id'], 'fields': fields})
 
     rc = {

--- a/nozama-cloudsearch-data/nozama/cloudsearch/data/tests/test_backend_searching.py
+++ b/nozama-cloudsearch-data/nozama/cloudsearch/data/tests/test_backend_searching.py
@@ -94,3 +94,12 @@ def test_basic_search(logger, mongodb, elastic):
     query = dict(q="not in any string")
     results = document.search(query)
     assert results['hits']['found'] == 0
+
+    # return in sdk format
+    query = dict(q="pro", format="sdk")
+    results = document.search(query)
+    for key, value in doc.items():
+        if not isinstance(value, list):
+            doc[key] = [value]
+    assert results['hits']['found'] == 1
+    assert results['hits']['hit'] == [{'id': '1246', 'fields': doc}]

--- a/nozama-cloudsearch-data/nozama/cloudsearch/data/tests/test_backend_searching.py
+++ b/nozama-cloudsearch-data/nozama/cloudsearch/data/tests/test_backend_searching.py
@@ -73,7 +73,7 @@ def test_basic_search(logger, mongodb, elastic):
     # return all:
     results = document.search()
     assert results['hits']['found'] == 2
-    c = [{'id': '1247'}, {'id': '1246'}]
+    c = [{'id': '1247', 'fields': doc2}, {'id': '1246', 'fields': doc}]
     c.sort()
     results['hits']['hit'].sort()
     assert results['hits']['hit'] == c
@@ -82,7 +82,7 @@ def test_basic_search(logger, mongodb, elastic):
     query = dict(q="pro")
     results = document.search(query)
     assert results['hits']['found'] == 1
-    assert results['hits']['hit'] == [{'id': '1246'}]
+    assert results['hits']['hit'] == [{'id': '1246', 'fields': doc}]
 
     query = dict(q="myshop")
     results = document.search(query)


### PR DESCRIPTION
This pul request has two purposes.

### Return field values
By default, CloudSearch returns all return enabled fields. 
See: http://docs.aws.amazon.com/cloudsearch/latest/developerguide/retrieving-data.html

`nozama-cloudsearch` has no support for return enabled fields option. It would be better to return all fields by default.(2796139)

### Support for `sdk` format
Add support for `format=sdk`(0092411).

I'm using aws-sdk-ruby as CloudSearch client. It sends a search request to CloudSearch with `format=sdk` query, and then CloudSearch returns field values in array format regardless of index field types.

```
hit: [
  {
    fields: {
      name: ["hokuma"],
      country: ["japan"],
    },
    id: "1"
  }
]
```

I can't find `format` query option in official documentation, but aws-sdk-ruby has a api definition in which the endpoint includes `format=sdk` query(https://github.com/aws/aws-sdk-ruby/blob/master/aws-sdk-core/apis/cloudsearchdomain/2013-01-01/api-2.json#L17)
