### PR TITLE
Add support for multibyte characters

### DIFF
--- a/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
+++ b/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py
@@ -133,7 +133,7 @@ def search(query={}):
             query = {
                 "query": {
                     "query_string": {
-                        "query": "{0}*".format(qstring)
+                        "query": u"{0}*".format(qstring)
                     }
                 }
             }
@@ -164,7 +164,7 @@ def search(query={}):
 
     rc = {
         "rank": "-text_relevance",
-        "match-expr": "(label '{0}')".format(qstring),
+        "match-expr": u"(label '{0}')".format(qstring),
         "hits": {
             "found": results['hits']['total'],
             "start": 0,


### PR DESCRIPTION
Search by multibyte chacaters(ex. japanese characters) raise a `UnicodeEncodeError`.

```
File "/Users/ohkuma/workspace/nozama-cloudsearch/nozama-cloudsearch-data/nozama/cloudsearch/data/document.py", line 136, in search
  "query": "{0}*".format(qstring)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u79c0' in position 0: ordinal not in range(128)
```

I don't have detail knowledge about string encoding in python, but this modification goes well.