### PR TITLE
Allow using POST method to request /search API

### DIFF
--- a/nozama-cloudsearch-service/nozama/cloudsearch/service/nozamaviews.py
+++ b/nozama-cloudsearch-service/nozama/cloudsearch/service/nozamaviews.py
@@ -18,7 +18,7 @@ def get_log(e=None):
 
 
 @view_config(
-    route_name='doc_search', request_method='GET', renderer='json'
+    route_name='doc_search', request_method=('POST', 'GET'), renderer='json'
 )
 def doc_search(request):
     """Handles quering of the stored documents.


### PR DESCRIPTION
According to the following documentation, CloudSearch seems to allow submitting search requests using POST method.

https://docs.aws.amazon.com/cloudsearch/latest/developerguide/submitting-search-requests.html

> You can use any method you want to send HTTP requests directly to your domain's search endpoint—you can enter the request URL directly in a Web browser, use cURL to submit the request, or generate an HTTP call using your favorite HTTP library. To specify your search criteria, you specify a query string that specifies the constraints for your search and what you want to get back in the response. The query string must be URL-encoded. The maximum size of a search request submitted via GET is 8190 bytes, including the HTTP method, URI, and protocol version. You can submit larger requests using HTTP POST; however, keep in mind that large, complex requests take longer to process and are more likely to time out. For more information

And, when using [Aws::CloudSearchDomain::Client](http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudSearchDomain/Client.html) of `aws-sdk ruby`, [Aws::Plugins::CSDSwitchToPost](http://docs.aws.amazon.com/sdkforruby/api/Aws/Plugins/CSDSwitchToPost.html) is applied, so a POST request is sent.

So, I tried changing search API to accept POST method, what do you think?